### PR TITLE
We don't need follow module overrides as they were included in ads_tm_in...

### DIFF
--- a/sass/contrib/follow.scss
+++ b/sass/contrib/follow.scss
@@ -1,6 +1,0 @@
-#block-follow-site {
-  > .block-title,
-  > .content {
-    display: inline-block;
-  }
-}

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -1,20 +1,10 @@
 /**
  * @file
- * Styles are organized using the SMACSS technique. @see http://smacss.com/book/
- *
- * When you turn on CSS aggregation at admin/config/development/performance, all
- * of these @include files will be combined into a single file.
+ * Styles for ADS base theme.
  */
 
 /* Import Sass mixins, variables, Compass modules, etc. */
 @import "init";
 
-@import "module-overrides";
-
 /* Load common styles for contrib modules. */
-@import "contrib/follow";
 @import "contrib/quickbar";
-
-/* SMACSS theme rules */
-/* @import "theme-A"; */
-/* @import "theme-B"; */


### PR DESCRIPTION
...ter_comf theme and other themes could need to have different appearance [ADS-72]
